### PR TITLE
Changing sprite source in a running game.

### DIFF
--- a/ga.js
+++ b/ga.js
@@ -1527,18 +1527,20 @@ GA.create = function(width, height, setup, assetsToLoad, load) {
   ga.sprite = function(source) {
     var o = {};
 
-    //Make this a display object.
-    makeDisplayObject(o);
-    o.frames = [];
-    o.loop = true;
-    o._currentFrame = 0;
-
     //This next part is complicated. The code has to figure out what
     //the source is referring to, and then assign its properties
     //correctly to the sprite's properties. Read carefully!
     //If no `source` is provided, alert the user.
     if (source === undefined) throw new Error("Sprites require a source");
 
+    //Make this a display object.
+    makeDisplayObject(o);
+    o.frames = [];
+    o.loop = true;
+    o._currentFrame = 0;
+    o.setTexture(source);
+
+    o.setTexture = function(source) {
     //If the source is just an ordinary string, use it to create the
     //sprite.
     if (!source.image) {
@@ -1639,7 +1641,8 @@ GA.create = function(width, height, setup, assetsToLoad, load) {
       o.sourceWidth = source.width;
       o.sourceHeight = source.height;
     }
-
+    };
+    
     //Add a `gotoAndStop` method to go to a specific frame.
     o.gotoAndStop = function(frameNumber) {
       if (o.frames.length > 0) {


### PR DESCRIPTION
Currently if one want to change a sprite `source` in a running game it will have to be done manually i.e changing source requires to change sourceX, sourceY, sourceWidth, sourceHeight, width, height and also we will need to remember the type of source ... It will be good to have a method like `setTexture` to do all this. A small change to the existing code is required.