### PR TITLE
Fix incorrect fullscreen check and sineCubed typo

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -4695,7 +4695,7 @@ GA.plugins = function(ga) {
   //to `fullscreen.scale`. If not, and the canvas hasn't already
   //been scaled, the scale reverts back to 1.   
   ga.scaleFullscreen = function() {
-    if(document.fullscreenEnabled) {
+    if(document.fullscreenElement != null) {
       ga.scale = ga.fullscreenScale;
       ga.pointer.scale = ga.fullscreenScale;
     } else {

--- a/plugins.js
+++ b/plugins.js
@@ -1156,7 +1156,7 @@ GA.plugins = function(ga) {
     //Sine
     sine: function(x) {return Math.sin(x * Math.PI / 2);},
     sineSquared: function(x) {return Math.pow(Math.sin(x * Math.PI / 2), 2);},
-    sineCubed: function(x) {return Math.pow(Math.sin(x * Math.PI / 2), 2);},
+    sineCubed: function(x) {return Math.pow(Math.sin(x * Math.PI / 2), 3);},
     inverseSine: function(x) {return 1 - Math.sin((1 - x) * Math.PI / 2);},
     inverseSineSquared: function(x) {return 1 - Math.pow(Math.sin((1 - x) * Math.PI / 2), 2);},
     inverseSineCubed: function(x) {return 1 - Math.pow(Math.sin((1 - x) * Math.PI / 2), 3);},


### PR DESCRIPTION
Fixes a problem introduced with the addition of fullscreen. Previously, the pointer placement had been incorrectly scaled due to the scale constantly resetting, which was caused by an incorrect call to fullscreenEnabled, which checks whether or not a browser *can support* fullscreen, rather than if it is currently. It has been replaced in this PR with checking if there are any current elements of the page in fullscreen; if none (`document.fullscreenElement != null`), then it is considered not fullscreen. Otherwise, it is.

This should fix #65 and potentially help with solving #33, #45, and #78.

Also will fix #72's typo.