### PR TITLE
Fix incorrect fullscreen check

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -4695,7 +4695,7 @@ GA.plugins = function(ga) {
   //to `fullscreen.scale`. If not, and the canvas hasn't already
   //been scaled, the scale reverts back to 1.   
   ga.scaleFullscreen = function() {
-    if(document.fullscreenEnabled) {
+    if(document.fullscreenElement != null) {
       ga.scale = ga.fullscreenScale;
       ga.pointer.scale = ga.fullscreenScale;
     } else {

--- a/plugins.js
+++ b/plugins.js
@@ -4556,7 +4556,7 @@ GA.plugins = function(ga) {
   //`requestFullscreen` is used by `enableFullscreen` to launch
   //fullscreen mode.
   ga.requestFullScreen = function() {
-    if (!document.fullscreenEnabled) {
+    if (document.fullscreenEnabled && document.fullscreenElement === null) {
       ga.canvas.requestFullscreen();
     }
   };
@@ -4564,7 +4564,7 @@ GA.plugins = function(ga) {
   //`exitFullscreen` is used by `enableFullscreen` to exit
   //fullscreen mode.
   ga.exitFullScreen = function() {
-    if (document.fullscreenEnabled) {
+    if (document.fullscreenEnabled && document.fullscreenElement !== null) {
       document.exitFullscreen();
     }
   };


### PR DESCRIPTION
Fixes a problem introduced with the addition of fullscreen. Previously, the pointer placement had been incorrectly scaled due to the scale constantly resetting, which was caused by an incorrect call to fullscreenEnabled, which checks whether or not a browser *can support* fullscreen, rather than if it is currently. It has been replaced in this PR with checking if there are any current elements of the page in fullscreen; if none (`document.fullscreenElement != null`), then it is considered not fullscreen. Otherwise, it is.

This should fix #65 and potentially help with solving #33.

Update: found other areas of code with the same issue. Flappy Fairy now goes properly fullscreen. Fixes #45 and #78.