### PR TITLE
Remove unneeded custom.js call

### DIFF
--- a/examples/32_blockRectangles.html
+++ b/examples/32_blockRectangles.html
@@ -4,7 +4,6 @@
 <body>
 <script src="../ga.js"></script>
 <script src="../plugins.js"></script>
-<script src="custom.js"></script>
 <script>
 
 /*


### PR DESCRIPTION
Removes the reference to a non-existent custom.js in the blockrectangles example.

Fixes #62. (Unless the intent was to actually have other code?)