### PR TITLE
Update plugins.js

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -4390,7 +4390,7 @@ GA.plugins = function(ga) {
             //matches the current tile, and that sub-object has a `name` property,
             //then create a sprite and assign the tile properties onto
             //the sprite
-            if (tileproperties[key] && tileproperties[key].name) {
+            if (typeof tileproperties !== 'undefined' && tileproperties[key] && tileproperties[key].name) {
 
               //Make a sprite
               tileSprite = ga.sprite(texture);


### PR DESCRIPTION
I guess by default it is assumed you have at least one tile in the tileset that has a custom "name" property, which might not be the case.

This make sure it works even when no custom properties where added to the tileset.